### PR TITLE
Adjust versioning for CI/CD

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -58,7 +58,7 @@ jobs:
           # on new tag / release
           type=semver,pattern={{version}},event=tag,enable=${{ env.IS-TAG == 'true' }}
           # add global tag
-          type=raw,priority=200,value=${{ steps.global-tag.outputs.tag }}
+          type=raw,priority=700,value=${{ steps.global-tag.outputs.tag }}
 
     - uses: docker/build-push-action@v3
       with:

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -58,7 +58,7 @@ jobs:
           # on new tag / release
           type=semver,pattern={{version}},event=tag,enable=${{ env.IS-TAG == 'true' }}
           # add global tag
-          type=raw,priority=1000,value=${{ steps.global-tag.outputs.tag }}
+          type=raw,priority=200,value=${{ steps.global-tag.outputs.tag }}
 
     - uses: docker/build-push-action@v3
       with:

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -30,22 +30,40 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ github.token }}
 
+    # determine the global tag to append to the image, 'latest', 'edge', or 'cutting-edge'
+    # outputs 'tag' and 'custom-version'
+    - id: global-tag
+      run: |
+        is_tag="${{ env.IS-TAG }}"
+        is_default="${{ steps.branch-name.outputs.is_default }}"
+
+        if [ "$is_tag" == "true" ]; then
+          echo "tag=latest" >> "$GITHUB_OUTPUT"
+        elif [ "$is_tag" == "false" ] && [ "$is_default" == "true" ]; then
+          echo "tag=edge" >> "$GITHUB_OUTPUT"
+          echo "custom-version=edge" >> "$GITHUB_OUTPUT"
+        elif [ "$is_tag" == "false" ] && [ "$is_default" == "false" ]; then
+          echo "tag=cutting-edge" >> "$GITHUB_OUTPUT"
+          echo "custom-version=cutting-edge" >> "$GITHUB_OUTPUT"
+        fi
+
     - id: meta
       uses: docker/metadata-action@v4
       with:
-        flavor: latest=auto
+        flavor: latest=false
         images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
         tags: |
           # for non-tagged pushes
           type=sha,format=short,prefix={{branch}}-,event=branch,enable=${{ env.IS-TAG == 'false' }}
-          type=edge,branch=main,event=branch,enable=${{ env.IS-TAG == 'false' }}
-          type=raw,priority=800,value=cutting-edge,enable=${{ steps.branch-name.outputs.is_default == 'false' && env.IS-TAG == 'false' }}
           # on new tag / release
           type=semver,pattern={{version}},event=tag,enable=${{ env.IS-TAG == 'true' }}
+          # add global tag
+          type=raw,priority=1000,value=${{ steps.global-tag.outputs.tag }}
 
     - uses: docker/build-push-action@v3
       with:
         context: .
+        build-args: CUSTOM_VERSION=${{ steps.global-tag.outputs.custom-version }}
         file: ./src/Dockerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/readme.md
+++ b/readme.md
@@ -2,3 +2,5 @@
 - .NET 7 based, redis backed
 - Rapidly integrated using GitHub Actions
 - Rapidly deployed using flux image automation
+
+## test

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 ﻿FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
-ARG CUSTOM_VERSION="test"
+ARG CUSTOM_VERSION=""
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,5 @@
 ﻿FROM mcr.microsoft.com/dotnet/runtime:7.0 AS base
+ARG CUSTOM_VERSION="test"
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
@@ -19,4 +20,5 @@ RUN dotnet publish "Miha.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+ENV MIHA_CUSTOM_VERSION=${CUSTOM_VERSION}
 ENTRYPOINT ["dotnet", "Miha.dll"]

--- a/src/Miha.Discord/Extensions/EmbedExtensions.cs
+++ b/src/Miha.Discord/Extensions/EmbedExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using Discord;
+using Miha.Shared;
 
 namespace Miha.Discord.Extensions;
 
 public static class EmbedExtensions
 {
     public static EmbedBuilder WithVersionFooter(this EmbedBuilder builder) =>
-        builder.WithFooter("miha-" + ThisAssembly.Git.Commit);
+        builder.WithFooter(Versioning.GetVersion());
 }

--- a/src/Miha.Discord/Miha.Discord.csproj
+++ b/src/Miha.Discord/Miha.Discord.csproj
@@ -10,10 +10,6 @@
     <PackageReference Include="Cronos" Version="0.7.1" />
     <PackageReference Include="Discord.Addons.Hosting" Version="5.2.0" />
     <PackageReference Include="Discord.Net" Version="3.11.0" />
-    <PackageReference Include="GitInfo" Version="3.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="SlimMessageBus" Version="2.0.1" />
     <PackageReference Include="SlimMessageBus.Host.Memory" Version="2.1.8" />
   </ItemGroup>
@@ -21,5 +17,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Miha.Logic\Miha.Logic.csproj" />
   </ItemGroup>
-    
+
 </Project>

--- a/src/Miha.Discord/Services/SlimMessageBusService.cs
+++ b/src/Miha.Discord/Services/SlimMessageBusService.cs
@@ -4,6 +4,7 @@ using Discord.Addons.Hosting.Util;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Miha.Discord.Consumers;
+using Miha.Shared;
 using SlimMessageBus;
 
 namespace Miha.Discord.Services;
@@ -29,6 +30,6 @@ public class SlimMessageBusService : DiscordClientService
         Client.GuildScheduledEventUpdated += (_, @event) => _bus.Publish(@event, Topics.GuildEvent.Updated, cancellationToken: stoppingToken);
 
         await Client.WaitForReadyAsync(stoppingToken);
-        await Client.SetActivityAsync(new Game("on miha-" + ThisAssembly.Git.Commit));
+        await Client.SetActivityAsync(new Game("on " + Versioning.GetVersion()));
     }
 }

--- a/src/Miha.Shared/Miha.Shared.csproj
+++ b/src/Miha.Shared/Miha.Shared.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitInfo" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />

--- a/src/Miha.Shared/Versioning.cs
+++ b/src/Miha.Shared/Versioning.cs
@@ -16,8 +16,9 @@ public static class Versioning
         }
         else
         {
+            version.Append('v');
             version.Append(Git.BaseVersion.Major).Append('.').Append(Git.BaseVersion.Minor).Append('.').Append(Git.BaseVersion.Patch);
-            version.Append(' ').Append(Git.Commit);
+            version.Append('-').Append(Git.Commit);
         }
 
         return version.ToString();

--- a/src/Miha.Shared/Versioning.cs
+++ b/src/Miha.Shared/Versioning.cs
@@ -8,11 +8,11 @@ public static class Versioning
     public static string GetVersion()
     {
         var version = new StringBuilder();
-        var versionPrefix = Environment.GetEnvironmentVariable("MIHA_VERSION_PREFIX");
+        var customVersion = Environment.GetEnvironmentVariable("MIHA_CUSTOM_VERSION");
 
-        if (!string.IsNullOrEmpty(versionPrefix))
+        if (!string.IsNullOrEmpty(customVersion))
         {
-            version.Append(versionPrefix).Append(' ').Append(Git.Commit);
+            version.Append(customVersion).Append(' ').Append(Git.Commit);
         }
         else
         {

--- a/src/Miha.Shared/Versioning.cs
+++ b/src/Miha.Shared/Versioning.cs
@@ -1,0 +1,25 @@
+﻿using System.Text;
+using static ThisAssembly;
+
+namespace Miha.Shared;
+
+public static class Versioning
+{
+    public static string GetVersion()
+    {
+        var version = new StringBuilder();
+        var versionPrefix = Environment.GetEnvironmentVariable("MIHA_VERSION_PREFIX");
+
+        if (!string.IsNullOrEmpty(versionPrefix))
+        {
+            version.Append(versionPrefix).Append(' ').Append(Git.Commit);
+        }
+        else
+        {
+            version.Append(Git.BaseVersion.Major).Append('.').Append(Git.BaseVersion.Minor).Append('.').Append(Git.BaseVersion.Patch);
+            version.Append(' ').Append(Git.Commit);
+        }
+
+        return version.ToString();
+    }
+}


### PR DESCRIPTION
# Modifications
- Add an optional environment variable that will prefix our version displayed in various areas in the bot, if that prefix is present it will display it alongside the commit sha, this will help in displaying our "cutting-edge" or "edge" versions if we happen to deploy them
- Pass that version via the build arg
- Adjust the workflows to generate said custom version & pass it down