### PR TITLE
Fix appsettings.json fs.inotify

### DIFF
--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -22,6 +22,8 @@ try
     var host = Host.CreateDefaultBuilder(args)
         .ConfigureAppConfiguration(builder =>
         {
+            // Disable ReloadOnChange for all sources, we don't intend to support this
+            // and it creates a lot of inotify issues on docker hosts running on linux
             foreach (var s in builder.Sources)
             {
                 if (s is FileConfigurationSource source)

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -20,7 +20,11 @@ try
     Log.Information("Starting host");
 
     var host = Host.CreateDefaultBuilder(args)
-        .ConfigureAppConfiguration(builder => builder.AddEnvironmentVariables())
+        .ConfigureAppConfiguration(builder =>
+        {
+            builder.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
+            builder.AddEnvironmentVariables();
+        })
         .UseSerilog()
         .ConfigureDiscordHost((context, config) =>
         {

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -22,8 +22,12 @@ try
     var host = Host.CreateDefaultBuilder(args)
         .ConfigureAppConfiguration(builder =>
         {
-            builder.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
-            builder.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: false);
+            foreach (var s in builder.Sources)
+            {
+                if (s is FileConfigurationSource source)
+                    source.ReloadOnChange = false;
+            }
+
             builder.AddEnvironmentVariables();
         })
         .UseSerilog()

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -23,6 +23,7 @@ try
         .ConfigureAppConfiguration(builder =>
         {
             builder.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false);
+            builder.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: false);
             builder.AddEnvironmentVariables();
         })
         .UseSerilog()


### PR DESCRIPTION
With default hosts, for some reason we hit a fs.inotify limit whenever the container boots up in a k8s environment

Since we don't even use appsettings.json reloadOnChange, let's just disable it outright for everything