### PR TITLE
Fix "Starting soon" announcement when creator is null & Tweak logging

### DIFF
--- a/src/Miha.Discord/Consumers/GuildEvent/GuildEventCancelledConsumer.cs
+++ b/src/Miha.Discord/Consumers/GuildEvent/GuildEventCancelledConsumer.cs
@@ -28,6 +28,12 @@ public class GuildEventCancelledConsumer : IConsumer<IGuildScheduledEvent>
         var loggingChannel = await _guildService.GetLoggingChannelAsync(guildEvent.Guild.Id);
         if (loggingChannel.IsFailed)
         {
+            if (loggingChannel.Reasons.Any(m => m.Message == "Logging channel not set"))
+            {
+                _logger.LogDebug("Guild logging channel not set {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
+                return;
+            }
+
             _logger.LogInformation("Failed getting logging channel for guild {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
             return;
         }

--- a/src/Miha.Discord/Consumers/GuildEvent/GuildEventCreatedConsumer.cs
+++ b/src/Miha.Discord/Consumers/GuildEvent/GuildEventCreatedConsumer.cs
@@ -28,6 +28,12 @@ public class GuildEventCreatedConsumer : IConsumer<IGuildScheduledEvent>
         var loggingChannel = await _guildService.GetLoggingChannelAsync(guildEvent.Guild.Id);
         if (loggingChannel.IsFailed)
         {
+            if (loggingChannel.Reasons.Any(m => m.Message == "Logging channel not set"))
+            {
+                _logger.LogDebug("Guild logging channel not set {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
+                return;
+            }
+
             _logger.LogInformation("Failed getting logging channel for guild {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
             return;
         }

--- a/src/Miha.Discord/Consumers/GuildEvent/GuildEventStartedConsumer.cs
+++ b/src/Miha.Discord/Consumers/GuildEvent/GuildEventStartedConsumer.cs
@@ -29,6 +29,12 @@ public class GuildEventStartedConsumer : IConsumer<IGuildScheduledEvent>
         var announcementChannel = await _guildService.GetAnnouncementChannelAsync(guildEvent.Guild.Id);
         if (announcementChannel.IsFailed)
         {
+            if (announcementChannel.Reasons.Any(m => m.Message == "Announcement channel not set"))
+            {
+                _logger.LogDebug("Guild announcement channel not set {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
+                return;
+            }
+
             _logger.LogInformation("Failed getting announcement channel for guild {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
             return;
         }

--- a/src/Miha.Discord/Consumers/GuildEvent/GuildEventUpdatedConsumer.cs
+++ b/src/Miha.Discord/Consumers/GuildEvent/GuildEventUpdatedConsumer.cs
@@ -28,6 +28,12 @@ public class GuildEventUpdatedConsumer : IConsumer<IGuildScheduledEvent>
         var loggingChannel = await _guildService.GetLoggingChannelAsync(guildEvent.Guild.Id);
         if (loggingChannel.IsFailed)
         {
+            if (loggingChannel.Reasons.Any(m => m.Message == "Logging channel not set"))
+            {
+                _logger.LogDebug("Guild logging channel not set {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
+                return;
+            }
+
             _logger.LogInformation("Failed getting logging channel for guild {GuildId} {EventId}", guildEvent.Guild.Id, guildEvent.Id);
             return;
         }

--- a/src/Miha.Discord/Services/GuildEventMonitorService.cs
+++ b/src/Miha.Discord/Services/GuildEventMonitorService.cs
@@ -10,7 +10,6 @@ using Miha.Discord.Extensions;
 using Miha.Logic.Services.Interfaces;
 using Miha.Shared.ZonedClocks.Interfaces;
 using Newtonsoft.Json;
-using JsonSerializer = SpanJson.JsonSerializer;
 
 namespace Miha.Discord.Services;
 
@@ -124,7 +123,20 @@ public partial class GuildEventMonitorService : DiscordClientService
 
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug("GuildEvent {GuildEventJson}", JsonSerializer.Generic.Utf16.Serialize(guildEvent));
+                    _logger.LogDebug("GuildEvent {EventId} {GuildEventJson}", guildEvent.Id, JsonConvert.SerializeObject(new
+                    {
+                        guildEvent.StartTime,
+                        guildEvent.Id,
+                        guildEvent.EndTime,
+                        creator = guildEvent.Creator is null ? "null" : "[ ]",
+                        location = guildEvent.Location is null ? "null" : "[ ]",
+                        channel = guildEvent.Channel is null ? "null" : "[ ]",
+                        guildEvent.Status
+                    }, new JsonSerializerSettings
+                    {
+                        MaxDepth = 1,
+                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                    }));
                 }
 
                 if (guildEvent.Status is GuildScheduledEventStatus.Active)

--- a/src/Miha.Discord/Services/GuildEventMonitorService.cs
+++ b/src/Miha.Discord/Services/GuildEventMonitorService.cs
@@ -128,9 +128,9 @@ public partial class GuildEventMonitorService : DiscordClientService
                         guildEvent.StartTime,
                         guildEvent.Id,
                         guildEvent.EndTime,
-                        guildEvent.Creator,
-                        guildEvent.Location,
-                        guildEvent.Channel,
+                        creator = guildEvent.Creator is null ? "null" : "[ ]",
+                        location = guildEvent.Location is null ? "null" : "[ ]",
+                        channel = guildEvent.Channel is null ? "null" : "[ ]",
                         guildEvent.Status,
                     }, new JsonSerializerSettings
                     {

--- a/src/Miha.Discord/Services/GuildEventMonitorService.cs
+++ b/src/Miha.Discord/Services/GuildEventMonitorService.cs
@@ -156,7 +156,7 @@ public partial class GuildEventMonitorService : DiscordClientService
                         .WithValue(voiceChannel)
                         .WithIsInline(false));
                 }
-                else if (!string.IsNullOrEmpty(guildEvent.Creator.Username))
+                else if (!string.IsNullOrEmpty(guildEvent.Creator?.Username))
                 {
                     fields.Add(new EmbedFieldBuilder()
                         .WithName("Hosted by")

--- a/src/Miha.Discord/Services/GuildEventMonitorService.cs
+++ b/src/Miha.Discord/Services/GuildEventMonitorService.cs
@@ -10,6 +10,7 @@ using Miha.Discord.Extensions;
 using Miha.Logic.Services.Interfaces;
 using Miha.Shared.ZonedClocks.Interfaces;
 using Newtonsoft.Json;
+using JsonSerializer = SpanJson.JsonSerializer;
 
 namespace Miha.Discord.Services;
 
@@ -123,20 +124,7 @@ public partial class GuildEventMonitorService : DiscordClientService
 
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    _logger.LogDebug("GuildEvent {EventId} {GuildEventJson}", guildEvent.Id, JsonConvert.SerializeObject(new
-                    {
-                        guildEvent.StartTime,
-                        guildEvent.Id,
-                        guildEvent.EndTime,
-                        creator = guildEvent.Creator is null ? "null" : "[ ]",
-                        location = guildEvent.Location is null ? "null" : "[ ]",
-                        channel = guildEvent.Channel is null ? "null" : "[ ]",
-                        guildEvent.Status,
-                    }, new JsonSerializerSettings
-                    {
-                        MaxDepth = 1,
-                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-                    }));
+                    _logger.LogDebug("GuildEvent {GuildEventJson}", JsonSerializer.Generic.Utf16.Serialize(guildEvent));
                 }
 
                 if (guildEvent.Status is GuildScheduledEventStatus.Active)

--- a/src/Miha.Discord/Services/GuildEventMonitorService.cs
+++ b/src/Miha.Discord/Services/GuildEventMonitorService.cs
@@ -107,31 +107,33 @@ public partial class GuildEventMonitorService : DiscordClientService
 
                 var startsIn = guildEvent.StartTime - DateTime.UtcNow;
 
-                _logger.LogInformation("GuildEvent {EventId} starts in (pre-round) {StartsInTotalMinutes}", guildEvent.Id, startsIn.TotalMinutes);
-
                 // "Round" our minutes up
                 if (startsIn.Seconds <= 60)
                 {
                     startsIn = new TimeSpan(startsIn.Days, startsIn.Hours, startsIn.Minutes + 1, 0);
                 }
 
-                _logger.LogInformation("GuildEvent {EventId} starts in (rounded) {StartsInTotalMinutes}", guildEvent.Id, startsIn.TotalMinutes);
+                _logger.LogDebug("GuildEvent {EventId} starts in (rounded) {StartsInTotalMinutes}", guildEvent.Id, startsIn.TotalMinutes);
 
                 if (startsIn.TotalMinutes is < 5 or > 20 || _memoryCache.TryGetValue(guildEvent.Id, out bool notified) && notified)
                 {
+                    _logger.LogDebug("GuildEvent {EventId} starts too soon or is already notified", guildEvent.Id);
                     continue;
                 }
 
-                _logger.LogInformation("GuildEvent {EventId} {GuildEventJson}", guildEvent.Id, JsonConvert.SerializeObject(new
+                if (_logger.IsEnabled(LogLevel.Debug))
                 {
-                    guildEvent.StartTime,
-                    guildEvent.Id,
-                    guildEvent.EndTime,
-                    guildEvent.Creator,
-                    guildEvent.Location,
-                    guildEvent.Channel,
-                    guildEvent.Status,
-                }, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore }));
+                    _logger.LogDebug("GuildEvent {EventId} {GuildEventJson}", guildEvent.Id, JsonConvert.SerializeObject(new
+                    {
+                        guildEvent.StartTime,
+                        guildEvent.Id,
+                        guildEvent.EndTime,
+                        guildEvent.Creator,
+                        guildEvent.Location,
+                        guildEvent.Channel,
+                        guildEvent.Status,
+                    }, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore }));
+                }
 
                 if (guildEvent.Status is GuildScheduledEventStatus.Active)
                 {

--- a/src/Miha.Discord/Services/GuildEventMonitorService.cs
+++ b/src/Miha.Discord/Services/GuildEventMonitorService.cs
@@ -132,7 +132,11 @@ public partial class GuildEventMonitorService : DiscordClientService
                         guildEvent.Location,
                         guildEvent.Channel,
                         guildEvent.Status,
-                    }, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore }));
+                    }, new JsonSerializerSettings
+                    {
+                        MaxDepth = 1,
+                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                    }));
                 }
 
                 if (guildEvent.Status is GuildScheduledEventStatus.Active)

--- a/src/Miha.Logic/Services/GuildService.cs
+++ b/src/Miha.Logic/Services/GuildService.cs
@@ -41,7 +41,7 @@ public partial class GuildService : DocumentService<GuildDocument>, IGuildServic
             var logChannel = optionsResult.Value?.LogChannel;
             if (!logChannel.HasValue)
             {
-                _logger.LogInformation("Guild doesn't have a logging channel set {GuildId}", guildId);
+                _logger.LogDebug("Guild doesn't have a logging channel set {GuildId}", guildId);
                 return Result.Fail<ITextChannel>("Logging channel not set");
             }
 
@@ -72,14 +72,14 @@ public partial class GuildService : DocumentService<GuildDocument>, IGuildServic
             var optionsResult = await GetAsync(guildId);
             if (optionsResult.IsFailed)
             {
-                _logger.LogInformation("Guild doesn't have any document when trying to get announcement channel {GuildId}", guildId);
+                _logger.LogWarning("Guild doesn't have any document when trying to get announcement channel {GuildId}", guildId);
                 return optionsResult.ToResult<ITextChannel>();
             }
 
             var announcementChannel = optionsResult.Value?.AnnouncementChannel;
             if (!announcementChannel.HasValue)
             {
-                _logger.LogInformation("Guild doesn't have a announcement channel set {GuildId}", guildId);
+                _logger.LogDebug("Guild doesn't have a announcement channel set {GuildId}", guildId);
                 return Result.Fail<ITextChannel>("Announcement channel not set");
             }
 
@@ -110,14 +110,14 @@ public partial class GuildService : DocumentService<GuildDocument>, IGuildServic
             var optionsResult = await GetAsync(guildId);
             if (optionsResult.IsFailed)
             {
-                _logger.LogInformation("Guild doesn't have any document when trying to get announcement role {GuildId}", guildId);
+                _logger.LogWarning("Guild doesn't have any document when trying to get announcement role {GuildId}", guildId);
                 return optionsResult.ToResult<IRole>();
             }
 
             var announcementRoleId = optionsResult.Value?.AnnouncementRoleId;
             if (!announcementRoleId.HasValue)
             {
-                _logger.LogInformation("Guild doesn't have a announcement role set {GuildId}", guildId);
+                _logger.LogDebug("Guild doesn't have a announcement role set {GuildId}", guildId);
                 return Result.Fail<IRole>("Announcement role not set");
             }
 

--- a/src/Miha.Shared/Miha.Shared.csproj
+++ b/src/Miha.Shared/Miha.Shared.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="SpanJson" Version="4.0.1" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 

--- a/src/Miha.Shared/Miha.Shared.csproj
+++ b/src/Miha.Shared/Miha.Shared.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />

--- a/src/Miha.Shared/Miha.Shared.csproj
+++ b/src/Miha.Shared/Miha.Shared.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
-    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />

--- a/src/Miha.Shared/Miha.Shared.csproj
+++ b/src/Miha.Shared/Miha.Shared.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="SpanJson" Version="4.0.1" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>
 

--- a/src/Miha.sln
+++ b/src/Miha.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		appsettings.json = appsettings.json
 		Dockerfile = Dockerfile
 		..\docker-compose.dev.yml = ..\docker-compose.dev.yml
+		appsettings.edge.json = appsettings.edge.json
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Miha.Redis", "Miha.Redis\Miha.Redis.csproj", "{51E2A7AC-9B3D-4453-89E7-EF81DAE37E41}"

--- a/src/Miha/Miha.csproj
+++ b/src/Miha/Miha.csproj
@@ -12,7 +12,7 @@
     <Content Include="..\.dockerignore">
       <Link>.dockerignore</Link>
     </Content>
-    <Content Include="..\appsettings.json">
+    <Content Include="..\appsettings*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/Miha/Miha.csproj
+++ b/src/Miha/Miha.csproj
@@ -12,6 +12,9 @@
     <Content Include="..\.dockerignore">
       <Link>.dockerignore</Link>
     </Content>
+    <Content Include="..\appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -32,7 +32,11 @@ try
 
             builder.AddEnvironmentVariables();
         })
-        .UseSerilog()
+        .UseSerilog((context, logger) => logger
+            .Enrich.FromLogContext()
+            .Enrich.WithExceptionDetails()
+            .WriteTo.Console(new CompactJsonFormatter())
+            .ReadFrom.Configuration(context.Configuration))
         .ConfigureDiscordHost((context, config) =>
         {
             var discordOptions = context.Configuration.GetSection(DiscordOptions.Section).Get<DiscordOptions>();

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -33,10 +33,10 @@ try
             builder.AddEnvironmentVariables();
         })
         .UseSerilog((context, logger) => logger
+            .ReadFrom.Configuration(context.Configuration)
             .Enrich.FromLogContext()
             .Enrich.WithExceptionDetails()
-            .WriteTo.Console(new CompactJsonFormatter())
-            .ReadFrom.Configuration(context.Configuration))
+            .WriteTo.Console(new RenderedCompactJsonFormatter()))
         .ConfigureDiscordHost((context, config) =>
         {
             var discordOptions = context.Configuration.GetSection(DiscordOptions.Section).Get<DiscordOptions>();

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -8,12 +8,11 @@ using Miha.Discord;
 using Serilog;
 using Serilog.Exceptions;
 using Serilog.Formatting.Compact;
-using Serilog.Templates;
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithExceptionDetails()
-    .WriteTo.Console(new ExpressionTemplate("{ {@t, @l, @m, @r, @x} }\n"))
+    .WriteTo.Console(new RenderedCompactJsonFormatter())
     .CreateLogger();
 
 try
@@ -37,7 +36,7 @@ try
             .ReadFrom.Configuration(context.Configuration)
             .Enrich.FromLogContext()
             .Enrich.WithExceptionDetails()
-            .WriteTo.Console(new ExpressionTemplate("{ {@t, @l, @m, @r, @x} }\n")))
+            .WriteTo.Console(new RenderedCompactJsonFormatter()))
         .ConfigureDiscordHost((context, config) =>
         {
             var discordOptions = context.Configuration.GetSection(DiscordOptions.Section).Get<DiscordOptions>();

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -12,7 +12,7 @@ using Serilog.Formatting.Compact;
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithExceptionDetails()
-    .WriteTo.Console(new RenderedCompactJsonFormatter())
+    .WriteTo.Console(new CompactJsonFormatter())
     .CreateLogger();
 
 try
@@ -41,7 +41,7 @@ try
             .ReadFrom.Configuration(context.Configuration)
             .Enrich.FromLogContext()
             .Enrich.WithExceptionDetails()
-            .WriteTo.Console(new RenderedCompactJsonFormatter()))
+            .WriteTo.Console(new CompactJsonFormatter()))
         .ConfigureDiscordHost((context, config) =>
         {
             var discordOptions = context.Configuration.GetSection(DiscordOptions.Section).Get<DiscordOptions>();

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -12,7 +12,7 @@ using Serilog.Formatting.Compact;
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithExceptionDetails()
-    .WriteTo.Console(new CompactJsonFormatter())
+    .WriteTo.Console(new RenderedCompactJsonFormatter())
     .CreateLogger();
 
 try

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -8,11 +8,12 @@ using Miha.Discord;
 using Serilog;
 using Serilog.Exceptions;
 using Serilog.Formatting.Compact;
+using Serilog.Templates;
 
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithExceptionDetails()
-    .WriteTo.Console(new RenderedCompactJsonFormatter())
+    .WriteTo.Console(new ExpressionTemplate("{ {@t, @l, @m, @r, @x} }\n"))
     .CreateLogger();
 
 try
@@ -36,7 +37,7 @@ try
             .ReadFrom.Configuration(context.Configuration)
             .Enrich.FromLogContext()
             .Enrich.WithExceptionDetails()
-            .WriteTo.Console(new RenderedCompactJsonFormatter()))
+            .WriteTo.Console(new ExpressionTemplate("{ {@t, @l, @m, @r, @x} }\n")))
         .ConfigureDiscordHost((context, config) =>
         {
             var discordOptions = context.Configuration.GetSection(DiscordOptions.Section).Get<DiscordOptions>();

--- a/src/Miha/Program.cs
+++ b/src/Miha/Program.cs
@@ -20,8 +20,13 @@ try
     Log.Information("Starting host");
 
     var host = Host.CreateDefaultBuilder(args)
-        .ConfigureAppConfiguration(builder =>
+        .ConfigureAppConfiguration((context, builder) =>
         {
+            if (context.HostingEnvironment.IsDevelopment())
+            {
+                builder.AddJsonFile("appsettings.edge.json", optional: true, reloadOnChange: false);
+            }
+
             // Disable ReloadOnChange for all sources, we don't intend to support this
             // and it creates a lot of inotify issues on docker hosts running on linux
             foreach (var s in builder.Sources)

--- a/src/Miha/Services/BirthdayScannerService.cs
+++ b/src/Miha/Services/BirthdayScannerService.cs
@@ -51,7 +51,7 @@ public class BirthdayScannerService : BackgroundService
                 continue;
             }
 
-            _logger.LogInformation("Waiting {Time}", nextUtc.Value - utcNow);
+            _logger.LogDebug("Waiting {Time}", nextUtc.Value - utcNow);
             await Task.Delay(nextUtc.Value - utcNow, stoppingToken);
         }
     }

--- a/src/appsettings.edge.json
+++ b/src/appsettings.edge.json
@@ -1,0 +1,5 @@
+﻿{
+  "Serilog": {
+    "MinimumLevel": "Debug"
+  }
+}

--- a/src/appsettings.edge.json
+++ b/src/appsettings.edge.json
@@ -1,5 +1,5 @@
 ﻿{
   "Serilog": {
-    "MinimumLevel": "Information"
+    "MinimumLevel": "Debug"
   }
 }

--- a/src/appsettings.edge.json
+++ b/src/appsettings.edge.json
@@ -1,5 +1,5 @@
 ﻿{
   "Serilog": {
-    "MinimumLevel": "Debug"
+    "MinimumLevel": "Information"
   }
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,2 +1,5 @@
 ﻿{
+  "Serilog": {
+    "MinimumLevel": "Debug"
+  }
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
   "Serilog": {
-    "MinimumLevel": "Information"
+    "MinimumLevel": "Debug"
   }
 }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,5 +1,5 @@
 ﻿{
   "Serilog": {
-    "MinimumLevel": "Debug"
+    "MinimumLevel": "Information"
   }
 }


### PR DESCRIPTION
# Modifications
- Sometimes the guildEvent `Creator` is null before we try to send a new message, previously this was handled with a null-conditional access `?` but it was removed on accident, so let's add it back so that we get starting-soon messages again
- Reduce overall logging by sticking certain things into `Debug` instead of `Info`
- Add `appsettings.json`'s for default logger configuration