### PR TITLE
Allow News & Text channel types on Announcement channel configuration

### DIFF
--- a/src/Miha.Discord/Modules/Guild/ConfigureModule.cs
+++ b/src/Miha.Discord/Modules/Guild/ConfigureModule.cs
@@ -104,7 +104,7 @@ public class ConfigureModule : BaseInteractionModule
         [SlashCommand("channel", "Sets or updates the channel where birthday announcements will be posted")]
         public async Task ChannelAsync(
             [Summary(description: "The channel where today's birthday will be posted")]
-            [ChannelTypes(ChannelType.News, ChannelType.Voice)] ITextChannel channel,
+            [ChannelTypes(ChannelType.News, ChannelType.Text)] ITextChannel channel,
             [Summary(description: "Setting this to true will disable announcements, even if you set a channel")] bool disable = false)
         {
             var result = await _guildService.UpsertAsync(channel.GuildId, options => options.BirthdayAnnouncementChannel = disable ? null : channel.Id);

--- a/src/Miha.Discord/Modules/Guild/ConfigureModule.cs
+++ b/src/Miha.Discord/Modules/Guild/ConfigureModule.cs
@@ -51,7 +51,8 @@ public class ConfigureModule : BaseInteractionModule
 
         [SlashCommand("channel", "Sets or updates the channel where event announcements will be posted")]
         public async Task ChannelAsync(
-            [Summary(description: "The channel where announcements will be posted")] ITextChannel channel,
+            [Summary(description: "The channel where announcements will be posted")]
+            [ChannelTypes(ChannelType.News, ChannelType.Text)] ITextChannel channel,
             [Summary(description: "Setting this to true will disable announcements, even if you set a channel")] bool disable = false)
         {
             var result = await _guildService.UpsertAsync(channel.GuildId, options => options.AnnouncementChannel = disable ? null : channel.Id);
@@ -102,7 +103,8 @@ public class ConfigureModule : BaseInteractionModule
 
         [SlashCommand("channel", "Sets or updates the channel where birthday announcements will be posted")]
         public async Task ChannelAsync(
-            [Summary(description: "The channel where today's birthday will be posted")] ITextChannel channel,
+            [Summary(description: "The channel where today's birthday will be posted")]
+            [ChannelTypes(ChannelType.News, ChannelType.Voice)] ITextChannel channel,
             [Summary(description: "Setting this to true will disable announcements, even if you set a channel")] bool disable = false)
         {
             var result = await _guildService.UpsertAsync(channel.GuildId, options => options.BirthdayAnnouncementChannel = disable ? null : channel.Id);

--- a/src/Miha.Discord/Modules/Guild/ConfigureModule.cs
+++ b/src/Miha.Discord/Modules/Guild/ConfigureModule.cs
@@ -104,10 +104,12 @@ public class ConfigureModule : BaseInteractionModule
         [SlashCommand("channel", "Sets or updates the channel where birthday announcements will be posted")]
         public async Task ChannelAsync(
             [Summary(description: "The channel where today's birthday will be posted")]
-            [ChannelTypes(ChannelType.News, ChannelType.Text)] ITextChannel channel,
+            [ChannelTypes(ChannelType.News, ChannelType.Text)] IChannel channel,
             [Summary(description: "Setting this to true will disable announcements, even if you set a channel")] bool disable = false)
         {
-            var result = await _guildService.UpsertAsync(channel.GuildId, options => options.BirthdayAnnouncementChannel = disable ? null : channel.Id);
+            var textChannel = channel as ITextChannel;
+
+            var result = await _guildService.UpsertAsync(textChannel.GuildId, options => options.BirthdayAnnouncementChannel = disable ? null : channel.Id);
 
             if (result.IsFailed)
             {
@@ -117,7 +119,7 @@ public class ConfigureModule : BaseInteractionModule
 
             var fields = new EmbedFieldBuilder()
                 .WithName("Birthday announcement channel")
-                .WithValue(disable ? "Disabled" : channel.Mention);
+                .WithValue(disable ? "Disabled" : textChannel.Mention);
 
             await RespondSuccessAsync("Updated Birthday announcement Channel", fields);
         }


### PR DESCRIPTION
# Modifications
- Discord.NET uses channel types on parameters to facilitate what types of channels are allowed in the slash command
- Allow News & Text channel types for `/configure announcements channel` and `/configure birthdays channel`